### PR TITLE
Fix CSS href

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Dasmoto's Arts & Crafts</title>
-  <link href="./resources/css/style.css" type="text/css" rel="stylesheet">
+  <link href="./style.css" type="text/css" rel="stylesheet">
 </head>
 <body>
 


### PR DESCRIPTION
The css file in the repo lives on the root (`./style.css`), but the `link[href]` pointed to a related path in a nested folder.